### PR TITLE
Add stream-dynamic.py

### DIFF
--- a/cmm.py
+++ b/cmm.py
@@ -3,6 +3,7 @@ import random, sys
 import data, midi, experiments, patterns, chords
 from decimal import Decimal as fixed
 from IPython import embed
+import copy
 
 class Markov(object):
 
@@ -87,7 +88,7 @@ class Markov(object):
         mm = Markov()
         # shallow copies (TODO: deep copy?)
         mm.chain_length = self.chain_length
-        mm.markov = self.markov.copy()
+        mm.markov = {k: v[:] for k, v in self.markov.iteritems()}
         mm.states = self.states.copy()
         mm.state_chains = [ chain[:] for chain in self.state_chains ]
         return mm
@@ -101,7 +102,6 @@ class Markov(object):
         for chain in model.state_chains:
             mm.add(chain)
         return mm
-
 
 class State(object):
 

--- a/cmm.py
+++ b/cmm.py
@@ -410,8 +410,8 @@ def generate_song(mm, meta, bar, segmentation=False):
 
 if __name__ == '__main__':
     c = patterns.fetch_classifier()
-    segmentation = True
-    all_keys = False
+    segmentation = False
+    all_keys = True
 
     if len(sys.argv) == 4: # <midi-file> <start-bar> <end-bar>
         musicpiece = data.piece(sys.argv[1])

--- a/playback.py
+++ b/playback.py
@@ -114,10 +114,8 @@ def init_midi_channel():
     '''
 
     msg = mido.Message('note_on', note=60, channel=0)
-    on_event = Event(msg, 0)
-    on_event.send_midi()
+    Event(msg, 0).send_midi()
     raw_input('MIDI channel is now set up. Please reset MIDI devices before continuing. Press [Enter]')
     msg = mido.Message('note_off', note=60, channel=0)
-    off_event = Event(msg, 0)
-    off_event.send_midi()
+    Event(msg, 0).send_midi()
 

--- a/stream-cmm.py
+++ b/stream-cmm.py
@@ -3,10 +3,10 @@ Stream and play notes from a Markov Model constructed from a midi file, one stat
 
 Workflow:
 1. Read MIDI file and train a Markov Model -> mm
-2. Initialize a note_state_generator with the Markov Model -> nsgen
+2. Initialize a NoteStateGenerator with the Markov Model -> nsgen
 3. Initialize an instance of PlaybackUtility -> pbu
 4. Loop:
-    - generate the next NoteState from the note_state_generator
+    - generate the next NoteState from the NoteStateGenerator
     - obtain Notes from the NoteState, and add them to pbu
     - play those Notes using pbu
 
@@ -17,12 +17,14 @@ import data
 import playback
 import time
 
-def note_state_generator(mm):
+def NoteStateGenerator(mm):
     '''
     Generator function to generate NoteStates from the given Markov Model.
 
+    NOTE: Assumes a Markov model of NoteStates; does not yet handle a Markov model consisting of SegmentStates
+
     Usage:
-        gen = note_state_generator(mm) # initialization
+        gen = NoteStateGenerator(mm) # initialization
         note_state = next(gen, None) # generate the next note_state. Returns none there is no next state.
         if note_state == None:
             print "End!"
@@ -47,7 +49,7 @@ if __name__ == "__main__":
     mm = cmm.piece_to_markov_model(musicpiece, segmentation=False, all_keys=False)
 
     # initialize the note state generator
-    nsgen = note_state_generator(mm)
+    nsgen = NoteStateGenerator(mm)
 
     # init some parameters
     tempo_reciprocal = 1500 # 'speed' of playback. need to adjust this carefully, and by trial and error

--- a/stream-dynamic.py
+++ b/stream-dynamic.py
@@ -1,12 +1,19 @@
 """
-Stream and play notes from a Markov Model constructed from a midi file, one state at a time.
+Stream and play notes from Markov Models constructed from midi files, one state at a time.
+
+Accepts external signals to change its underlying Markov Model
 
 Workflow:
-1. Read MIDI file and train a Markov Model -> mm
-2. Initialize a note_state_generator with the Markov Model -> nsgen
+1. Read a list of MIDI files and train a pool of Markov Models -> markov_models
+2. Initialize a DynamicMarkovNoteStateGenerator with a random initial Markov Model -> dmnsg
+3. Obtain the note_state_generator from the DynamicMarkovNoteStateGenerator -> nsgen
 3. Initialize an instance of PlaybackUtility -> pbu
 4. Loop:
-    - generate the next NoteState from the note_state_generator
+    - poll trigger_file for a signal:
+        if given signal is an entry in the pool, schedule the corresponding Markov model to be the next
+        if given signal is 'random', schedule a random Markov model from the pool
+    - replace the current model with the scheduled model if a valid transition can be found
+    - generate the next NoteState from nsgen
     - obtain Notes from the NoteState, and add them to pbu
     - play those Notes using pbu
 
@@ -25,39 +32,37 @@ class DynamicMarkovNoteStateGenerator(object):
 
     NOTE: Assumes a Markov model of NoteStates; does not yet handle a Markov model consisting of SegmentStates
 
-    Usage:
-        gen = DynamicMarkovNoteStateGenerator(mm) # initialization
-        note_state = next(gen, None) # generate the next note_state. Returns none there is no next state.
-        if note_state == None:
-            print "End!"
     '''
 
-    def __init__(self, mm=None, markov_models={}, seed=[]):
+    def __init__(self, mm, markov_models, seed=[]):
         '''
         Initialize the DynamicMarkovNoteStateGenerator with an empty or already existing and trained Markov model
 
         Args:
-            mm: an initialized cmm.Markov object (if None, will default to an empty cmm.Markov)
+            mm: the initial underlying Markov model (default: empty cmm.Markov)
+            markov_models: a dictionary of midi filename -> trained cmm.Markov
             seed: optional; if provided, will build states from seed
 
         '''
 
-        if mm is None:
-            self.mm = cmm.Markov()
-        else:
-            self.mm = mm
-
-        self.buf = self.mm.get_start_buffer(seed)
+        self.mm = mm
+        self.buf = self.mm.get_start_buffer(seed) # current statechain, used for generating the next state with a lookup
         self.markov_models = markov_models
-        self.next_mm = None
+        self.next_mm = None # next scheduled Markov model
 
     def get_model_name(self):
+        '''
+        return the MIDI filename of the current underlying Markov model
+        '''
         for k, v in markov_models.iteritems():
             if self.mm == v:
                 return k
         return None
 
     def next_transition_exists(self, mm=None):
+        '''
+        return True if there is a valid state transition in the Markov model specified (mm)
+        '''
         if mm is None:
             mm = self.mm
         if tuple(self.buf) in mm.markov:
@@ -66,19 +71,41 @@ class DynamicMarkovNoteStateGenerator(object):
             return False
 
     def replace_markov_model(self, mm):
+        ''' replace the underlying Markov model immediately '''
         self.mm = mm
 
     def set_next_markov_model(self, mm):
+        ''' schedule the next Markov model to be used '''
         self.next_mm = mm
 
     def next_state_generator(self):
+        '''
+        Generator function to generate NoteStates from the the underlying Markov model.
+        When/if there is a valid transition from the current statechain in the next scheduled Markov model,
+        will switch its underlying Markov model to the scheduled
+
+        Usage:
+            dmnsg = DynamicMarkovNoteStateGenerator(mm) # initialization
+            gen = DynamicMarkovNoteStateGenerator.note_state_generator() # initialization of the generator
+            <enter loop>
+                <manipulate DynamicMarkovNoteStateGenerator using exposed functions>
+                note_state = next(gen, None) # generate the next note_state. Returns none there is no next state.
+                if note_state == None:
+                    print "End!"
+                    <exit loop>
+        '''
+
         elem = None
         while elem != cmm.Markov.STOP_TOKEN:
+            # see if next scheduled Markov model can be used
+            # if so, replace with the next scheduled model
             if self.next_mm and self.next_transition_exists(self.next_mm):
                 self.replace_markov_model(self.next_mm)
                 self.next_mm = None
                 print 'replace model with [{}]'.format(self.get_model_name())
-            elem = self.mm.generate_next_state(self.buf) # generate another
+
+            # generate the next NoteState
+            elem = self.mm.generate_next_state(self.buf)
             if elem != cmm.Markov.STOP_TOKEN:
                 self.buf = self.mm.shift_buffer(self.buf, elem)
                 yield elem
@@ -90,8 +117,9 @@ if __name__ == "__main__":
         filenames = ["mid/easywinners.mid", "mid/froglegs.mid", "mid/hilarity.mid", "mid/sjeugen.mid"]
     musicpieces = {f: data.piece(f) for f in filenames}
 
-    # train a markov model on each piece
-    # nothing fancy, no segmentation or key shifts
+    # train a markov model on each piece to make a pool of Markov models
+    # pair them up with their MIDI filenames and put inside a dictionary
+    # can turn on all_keys if desired
     markov_models = {f: cmm.piece_to_markov_model(piece, segmentation=False, all_keys=False) for f, piece in musicpieces.iteritems()}
 
     # initialize the note state generator with a random initial markov model
@@ -113,19 +141,21 @@ if __name__ == "__main__":
     start_time = time.clock()
     while loop:
         cur_time = time.clock()
+
+        # poll trigger_file for signals
         trigger_text = playback.read_trigger_file('trigger_file')
         if trigger_text:
             print 'received trigger text: [{}]'.format(trigger_text)
-            if trigger_text in markov_models.keys():
+            if trigger_text in markov_models.keys(): # schedule the next Markov model to be the one provided, if in the pool
                 dmnsg.set_next_markov_model(markov_models[trigger_text])
                 print 'set next model: [{}]'.format(trigger_text)
-            elif trigger_text == 'random':
+
+            elif trigger_text == 'random': # if signal is 'random', schedule a random Markov model from the pool
                 model_names = markov_models.keys()[:]
-                model_names.remove(dmnsg.get_model_name())
+                model_names.remove(dmnsg.get_model_name()) # prevent choosing the same model as the current
                 next_model = random.choice(model_names)
                 dmnsg.set_next_markov_model(markov_models[next_model])
                 print 'set next model: [{}]'.format(next_model)
-
 
         playback_pos = int((cur_time - start_time) * 1000000) / tempo_reciprocal
 

--- a/stream-dynamic.py
+++ b/stream-dynamic.py
@@ -1,0 +1,125 @@
+"""
+Stream and play notes from a Markov Model constructed from a midi file, one state at a time.
+
+Workflow:
+1. Read MIDI file and train a Markov Model -> mm
+2. Initialize a note_state_generator with the Markov Model -> nsgen
+3. Initialize an instance of PlaybackUtility -> pbu
+4. Loop:
+    - generate the next NoteState from the note_state_generator
+    - obtain Notes from the NoteState, and add them to pbu
+    - play those Notes using pbu
+
+"""
+
+import cmm
+import data
+import playback
+import time
+import sys, random
+
+class DynamicMarkovNoteStateGenerator(object):
+    '''
+    Generator function to generate NoteStates from an underlying Markov Model.
+    The underlying Markov Model is dynamic and can be manipulated through exposed functions
+
+    NOTE: Assumes a Markov model of NoteStates; does not yet handle a Markov model consisting of SegmentStates
+
+    Usage:
+        gen = DynamicMarkovNoteStateGenerator(mm) # initialization
+        note_state = next(gen, None) # generate the next note_state. Returns none there is no next state.
+        if note_state == None:
+            print "End!"
+    '''
+
+    def __init__(self, mm=None, seed=[]):
+        '''
+        Initialize the DynamicMarkovNoteStateGenerator with an empty or already existing and trained Markov model
+
+        Args:
+            mm: an initialized cmm.Markov object (if None, will default to an empty cmm.Markov)
+            seed: optional; if provided, will build states from seed
+
+        '''
+
+        if mm is None:
+            self.mm = cmm.Markov()
+        else:
+            self.mm = mm
+
+        self.buf = self.mm.get_start_buffer(seed)
+
+    def next_transition_exists(self, mm=None):
+        if mm is None:
+            mm = self.mm
+        if tuple(self.buf) in mm.markov:
+            return True
+        else:
+            return False
+
+    def replace_markov_model(self, mm):
+        if self.nextTransitionExists(mm):
+            self.mm = mm
+            return True
+        else:
+            return False
+
+    def next_state_generator(self):
+        elem = self.mm.generate_next_state(self.buf)
+        yield elem
+
+        while elem != cmm.Markov.STOP_TOKEN:
+            self.buf = self.mm.shift_buffer(self.buf, elem)
+            elem = self.mm.generate_next_state(self.buf) # generate another
+            if elem != cmm.Markov.STOP_TOKEN:
+                yield elem
+
+def handle_trigger(trigger_text, nsgen):
+    pass
+
+if __name__ == "__main__":
+    # load MIDI files (from program arguments if provided)
+    filenames = sys.argv[1:]
+    if not filenames:
+        filenames = ["mid/easywinners.mid", "mid/froglegs.mid", "mid/hilarity.mid", "mid/lost.mid", "mid/owl.mid", "mid/sjeugen.mid"]
+    musicpieces = {f: data.piece(f) for f in filenames}
+
+    # train a markov model on each piece
+    # nothing fancy, no segmentation or key shifts
+    markov_models = {f: cmm.piece_to_markov_model(piece, segmentation=False, all_keys=False) for f, piece in musicpieces.iteritems()}
+
+    # initialize the note state generator with a random initial markov model
+    initial_markov = random.choice(markov_models.values())
+    nsgen = DynamicMarkovNoteStateGenerator(initial_markov).next_state_generator()
+
+    # init some parameters
+    tempo_reciprocal = 1500 # 'speed' of playback. need to adjust this carefully, and by trial and error
+    bar = 1024 # used for generating the midi events
+    playback.init_midi_channel() # set up channel, and prompt MIDI device reset
+
+    # loop
+    loop = True
+    playback_pos = 0
+    next_pos = 0 # this is used as a marker for constructing MIDI events from NoteStates
+    pbu = playback.PlaybackUtility() # init the PlaybackUtility -> pbu
+
+    start_time = time.clock()
+    while loop:
+        cur_time = time.clock()
+        trigger_text = playback.read_trigger_file('trigger_file')
+        if trigger_text:
+            print 'received trigger text: [{}]'.format(trigger_text)
+            handle_trigger(trigger_text, nsgen)
+
+        playback_pos = int((cur_time - start_time) * 1000000) / tempo_reciprocal
+
+        if playback_pos >= next_pos:
+            note_state = next(nsgen, None) # generate the next note_state
+            if note_state:
+                notes, next_pos = note_state.to_notes(bar, next_pos)
+                pbu.add_notes(notes)
+
+        pbu.run(playback_pos)
+        if pbu.isTerminated():
+            loop = False
+

--- a/stream-dynamic.py
+++ b/stream-dynamic.py
@@ -32,7 +32,7 @@ class DynamicMarkovNoteStateGenerator(object):
             print "End!"
     '''
 
-    def __init__(self, mm=None, seed=[]):
+    def __init__(self, mm=None, markov_models={}, seed=[]):
         '''
         Initialize the DynamicMarkovNoteStateGenerator with an empty or already existing and trained Markov model
 
@@ -48,6 +48,14 @@ class DynamicMarkovNoteStateGenerator(object):
             self.mm = mm
 
         self.buf = self.mm.get_start_buffer(seed)
+        self.markov_models = markov_models
+        self.next_mm = None
+
+    def get_model_name(self):
+        for k, v in markov_models.iteritems():
+            if self.mm == v:
+                return k
+        return None
 
     def next_transition_exists(self, mm=None):
         if mm is None:
@@ -58,30 +66,28 @@ class DynamicMarkovNoteStateGenerator(object):
             return False
 
     def replace_markov_model(self, mm):
-        if self.nextTransitionExists(mm):
-            self.mm = mm
-            return True
-        else:
-            return False
+        self.mm = mm
+
+    def set_next_markov_model(self, mm):
+        self.next_mm = mm
 
     def next_state_generator(self):
-        elem = self.mm.generate_next_state(self.buf)
-        yield elem
-
+        elem = None
         while elem != cmm.Markov.STOP_TOKEN:
-            self.buf = self.mm.shift_buffer(self.buf, elem)
+            if self.next_mm and self.next_transition_exists(self.next_mm):
+                self.replace_markov_model(self.next_mm)
+                self.next_mm = None
+                print 'replace model with [{}]'.format(self.get_model_name())
             elem = self.mm.generate_next_state(self.buf) # generate another
             if elem != cmm.Markov.STOP_TOKEN:
+                self.buf = self.mm.shift_buffer(self.buf, elem)
                 yield elem
-
-def handle_trigger(trigger_text, nsgen):
-    pass
 
 if __name__ == "__main__":
     # load MIDI files (from program arguments if provided)
     filenames = sys.argv[1:]
     if not filenames:
-        filenames = ["mid/easywinners.mid", "mid/froglegs.mid", "mid/hilarity.mid", "mid/lost.mid", "mid/owl.mid", "mid/sjeugen.mid"]
+        filenames = ["mid/easywinners.mid", "mid/froglegs.mid", "mid/hilarity.mid", "mid/sjeugen.mid"]
     musicpieces = {f: data.piece(f) for f in filenames}
 
     # train a markov model on each piece
@@ -89,8 +95,9 @@ if __name__ == "__main__":
     markov_models = {f: cmm.piece_to_markov_model(piece, segmentation=False, all_keys=False) for f, piece in musicpieces.iteritems()}
 
     # initialize the note state generator with a random initial markov model
-    initial_markov = random.choice(markov_models.values())
-    nsgen = DynamicMarkovNoteStateGenerator(initial_markov).next_state_generator()
+    initial_markov = random.choice(markov_models.keys())
+    dmnsg = DynamicMarkovNoteStateGenerator(markov_models[initial_markov], markov_models)
+    nsgen = dmnsg.next_state_generator()
 
     # init some parameters
     tempo_reciprocal = 1500 # 'speed' of playback. need to adjust this carefully, and by trial and error
@@ -109,11 +116,21 @@ if __name__ == "__main__":
         trigger_text = playback.read_trigger_file('trigger_file')
         if trigger_text:
             print 'received trigger text: [{}]'.format(trigger_text)
-            handle_trigger(trigger_text, nsgen)
+            if trigger_text in markov_models.keys():
+                dmnsg.set_next_markov_model(markov_models[trigger_text])
+                print 'set next model: [{}]'.format(trigger_text)
+            elif trigger_text == 'random':
+                model_names = markov_models.keys()[:]
+                model_names.remove(dmnsg.get_model_name())
+                next_model = random.choice(model_names)
+                dmnsg.set_next_markov_model(markov_models[next_model])
+                print 'set next model: [{}]'.format(next_model)
+
 
         playback_pos = int((cur_time - start_time) * 1000000) / tempo_reciprocal
 
         if playback_pos >= next_pos:
+            print 'current model name: [{}]'.format(dmnsg.get_model_name())
             note_state = next(nsgen, None) # generate the next note_state
             if note_state:
                 notes, next_pos = note_state.to_notes(bar, next_pos)

--- a/stream-dynamic.py
+++ b/stream-dynamic.py
@@ -1,7 +1,7 @@
 """
 Stream and play notes from Markov Models constructed from midi files, one state at a time.
 
-Accepts external signals to change its underlying Markov Model
+Accepts external signals to schedule a change in its underlying Markov Model
 
 Workflow:
 1. Read a list of MIDI files and train a pool of Markov Models -> markov_models


### PR DESCRIPTION
Stream and play notes from Markov Models constructed from midi files, one state at a time.

Accepts external signals to schedule a change in its underlying Markov Model

Workflow:
1. Read a list of MIDI files and train a pool of Markov Models -> markov_models
2. Initialize a DynamicMarkovNoteStateGenerator with a random initial Markov Model -> dmnsg
3. Obtain the note_state_generator from the DynamicMarkovNoteStateGenerator -> nsgen
3. Initialize an instance of PlaybackUtility -> pbu
4. Loop:
    - poll trigger_file for a signal:
        if given signal is an entry in the pool, schedule the corresponding Markov model to be the next
        if given signal is 'random', schedule a random Markov model from the pool
    - replace the current model with the scheduled model if a valid transition can be found
    - generate the next NoteState from nsgen
    - obtain Notes from the NoteState, and add them to pbu
    - play those Notes using pbu
